### PR TITLE
refactor: thumbnail leftjoin 삭제

### DIFF
--- a/src/main/java/com/highgeupsik/backend/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/highgeupsik/backend/repository/BoardRepositoryImpl.java
@@ -38,7 +38,6 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
                 board.id, board.title, board.content, board.thumbnail, board.likeCount,
                 board.commentCount, board.createdDate))
             .from(board)
-            .leftJoin(uploadFile)
             .where(
                 regionEq(condition.getRegion()),
                 categoryEq(condition.getCategory()),


### PR DESCRIPTION
board entity의 thumbnail을 string으로 변경했기 때문에 leftjoin 삭제 했습니다 